### PR TITLE
DCD-261: Initial commit of Crowd Quickstart assets

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+templates:
+  - templates/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/taskcat_outputs
+*~
+*.bak
+/.idea
+\#*\#

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/quickstart-atlassian-services"]
+	path = submodules/quickstart-atlassian-services
+	url = https://github.com/aws-quickstart/quickstart-atlassian-services.git
+	branch = master

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,2 +1,202 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>CC97165EA7E5B8A3</RequestId><HostId>IPQseJWJXbs2nQJJ4riq7KyOUF7OWQKn1L2Wvt7nb56NLeBW40pbCikaxX9PmoZU4brfR1Far68=</HostId></Error>
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>671B936C9C711B65</RequestId><HostId>+rMuLI6HPbYuVnG7+rlT1/rZw+kD2ZUBQUGN4TXgyzP+wlY1x+c4fwvZ4rfjF1lCJ1dwEocgGjE=</HostId></Error>
+Copyright 2016-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# Project README
+# quickstart-atlassian-crowd
+## Crowd Software Data Center on the AWS Cloud
+
+Use this Quick Start to deploy Crowd Data Center on the AWS Cloud.
+
+Crowd enables you to manage users from multiple directories - Active Directory, LDAP, OpenLDAP or Microsoft Azure AD - and control application authentication permissions in one single location. Crowd Data Center is a self-managed solution that gives you high availability, performance at scale, and disaster recovery for uninterrupted access to Crowd for all your teams.
+
+This Quick Start uses the [Atlassian Standard Infrastructure (ASI)](https://fwd.aws/xYyYy) as a foundation. You can choose to build a new ASI for your deployment or deploy Crowd into your existing ASI. You can also deploy Jira, Confluence and Bitbucket Data Center within the same ASI.
+
+![Quick Start architecture for Crowd on AWS](https://d1.awsstatic.com/partner-network/QuickStart/datasheets/jira-arch-on-aws.9d422797475ea5bd5d38f009ca8c540736f5449e.png)
+
+For architectural details, best practices, step-by-step instructions, and customization options, see the 
+[deployment guide](https://fwd.aws/Wz3Qb).
+
+### Network prerequisites
+
+You need to create the required AWS networking infrastructure
+(VPC, subnets) by using the [ASI Quick Start](https://fwd.aws/xYyYy), or by deploying Crowd with a new ASI.
+For details, see the [deployment guide](https://fwd.aws/Wz3Qb).
+
+### Contributing & issues
+
+Please note that issues are disabled for this repository, because it is a
+downstream repository that is not actively supported.
+We welcome pull requests, issues, and comments in the **[upstream repository](https://bitbucket.org/atlassian/atlassian-aws-deployment/src/master/quickstarts/)**.
+
+If you'd like to submit code for this Quick Start, please review the [AWS Quick Start Contributor's Kit](https://aws-quickstart.github.io/). 
+
+## Development notes
+
+### Pre-commit hook
+
+It is recommended that you install the hooks under `submodules/quickstart-atlassian-services/scripts/hooks/`; this will
+ensure that the metadata tags in the templates are automatically updated on
+commit. The simplest method of doing this is:
+
+    git config --add core.hooksPath submodules/quickstart-atlassian-services/scripts/hooks/
+
+Alternatively you can invoke
+`submodules/quickstart-atlassian-services/scripts/hooks/update-tags.py`
+manually.

--- a/ci/params/default/quickstart-crowd-default-params.json
+++ b/ci/params/default/quickstart-crowd-default-params.json
@@ -1,0 +1,50 @@
+[
+    {
+        "ParameterKey": "InternetFacingLoadBalancer",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBStorage",
+        "ParameterValue": "100"
+    },
+    {
+        "ParameterKey": "DBStorageType",
+        "ParameterValue": "Provisioned IOPS"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-atlassian-crowd/"
+    },
+    {
+        "ParameterKey": "ClusterNodeInstanceType",
+        "ParameterValue": "t3.medium"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t3.medium"
+    }
+]

--- a/ci/params/default/taskcat.yml
+++ b/ci/params/default/taskcat.yml
@@ -1,0 +1,13 @@
+---
+global:
+  marketplace-ami: false
+  owner: dc-deployments-syd@atlassian.com
+  qsname: quickstart-atlassian-crowd
+  regions:
+    - us-east-1
+  reporting: true
+
+tests:
+  crowd:
+    parameter_input: params/default/quickstart-crowd-default-params.json
+    template_file: quickstart-crowd-dc.template.yaml

--- a/ci/params/ssl-and-dns/quickstart-crowd-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-crowd-ci-params.json
@@ -1,0 +1,58 @@
+[
+    {
+        "ParameterKey": "InternetFacingLoadBalancer",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBStorage",
+        "ParameterValue": "100"
+    },
+    {
+        "ParameterKey": "DBStorageType",
+        "ParameterValue": "Provisioned IOPS"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "CustomDnsName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "SSLCertificateARN",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "ClusterNodeInstanceType",
+        "ParameterValue": "t3.medium"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t3.medium"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-atlassian-crowd/"
+    }
+]

--- a/ci/params/ssl-and-dns/taskcat.yml
+++ b/ci/params/ssl-and-dns/taskcat.yml
@@ -1,0 +1,13 @@
+---
+global:
+  marketplace-ami: false
+  owner: dc-deployments-syd@atlassian.com
+  qsname: quickstart-atlassian-crowd
+  regions:
+    - us-east-1
+  reporting: true
+
+tests:
+  crowd:
+    parameter_input: params/ssl-and-dns/quickstart-crowd-ci-params.json
+    template_file: quickstart-crowd-dc.template.yaml

--- a/ci/quickstart-crowd-dc-params.json
+++ b/ci/quickstart-crowd-dc-params.json
@@ -1,0 +1,46 @@
+[
+    {
+        "ParameterKey": "AvailabilityZones",
+        "ParameterValue": "$[taskcat_genaz_2]"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBStorage",
+        "ParameterValue": "100"
+    },
+    {
+        "ParameterKey": "DBStorageType",
+        "ParameterValue": "Provisioned IOPS"
+    },
+    {
+        "ParameterKey": "CustomDnsName",
+        "ParameterValue": "qscrowdci.awsqs.com"
+    },
+    {
+        "ParameterKey":"QSS3BucketName",
+        "ParameterValue":"$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey":"QSS3KeyPrefix",
+        "ParameterValue":"quickstart-atlassian-crowd/"
+    },
+    {
+        "ParameterKey":"AccessCIDR",
+        "ParameterValue":"10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    }
+]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -1,0 +1,12 @@
+global:
+  marketplace-ami: false
+  owner: quickstart-eng@amazon.com
+  qsname: quickstart-atlassian-crowd
+  regions:
+    - us-east-1
+  reporting: true
+
+tests:
+  crowd:
+    parameter_input: quickstart-crowd-dc-params.json
+    template_file: quickstart-crowd-dc-with-vpc.template.yaml

--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -1,0 +1,734 @@
+---
+# Bring up diffs between this file and the BitbucketDataCenter.template.yaml, ConfluenceDataCenter.template.yaml, and CrowdDataCenter.template.yaml
+# As a rule, we should work to minimize our diffs between these files as best we can, so that future changes are easy to make across all supported CloudFormation templates.
+# Using YAML as our file format will allow us to put a block comment at the top of the file saying exactly this.
+AWSTemplateFormatVersion: 2010-09-09
+Description: Atlassian Crowd Data Center with VPC
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Crowd setup
+        Parameters:
+          - CrowdVersion
+      - Label:
+          default: Cluster nodes
+        Parameters:
+          - CloudWatchIntegration
+          - ClusterNodeInstanceType
+          - ClusterNodeMax
+          - ClusterNodeMin
+          - ClusterNodeVolumeSize
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
+          - DeploymentAutomationCustomParams
+      - Label:
+          default: Database
+        Parameters:
+          - DBInstanceClass
+          - DBIops
+          - DBMasterUserPassword
+          - DBMultiAZ
+          - DBPassword
+          - DBStorage
+          - DBStorageEncrypted
+          - DBStorageType
+      - Label:
+          default: Networking
+        Parameters:
+          - AccessCIDR
+          - AvailabilityZones
+          - InternetFacingLoadBalancer
+          - KeyPairName
+          - PrivateSubnet1CIDR
+          - PrivateSubnet2CIDR
+          - PublicSubnet1CIDR
+          - PublicSubnet2CIDR
+          - SSLCertificateARN
+          - VPCCIDR
+      - Label:
+          default: DNS (Optional)
+        Parameters:
+          - CustomDnsName
+          - HostedZone
+      - Label:
+          default: Application Tuning (Optional)
+        Parameters:
+          - TomcatContextPath
+          - CatalinaOpts
+          - JvmHeapOverride
+          - DBPoolMaxSize
+          - DBPoolMinSize
+          - DBMaxIdle
+          - DBMaxWaitMillis
+          - DBMinEvictableIdleTimeMillis
+          - DBMinIdle
+          - DBRemoveAbandoned
+          - DBRemoveAbandonedTimeout
+          - DBTestOnBorrow
+          - DBTestWhileIdle
+          - DBTimeBetweenEvictionRunsMillis
+          - MailEnabled
+          - TomcatAcceptCount
+          - TomcatConnectionTimeout
+          - TomcatDefaultConnectorPort
+          - TomcatEnableLookups
+          - TomcatMaxThreads
+          - TomcatMinSpareThreads
+          - TomcatProtocol
+          - TomcatRedirectPort
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+          - ExportPrefix
+
+    ParameterLabels:
+      AccessCIDR:
+        default: Trusted IP range
+      AvailabilityZones:
+        default: Availability Zones
+      CatalinaOpts:
+        default: Catalina options
+      CloudWatchIntegration:
+        default: Enable CloudWatch integration
+      ClusterNodeMax:
+        default: Maximum number of cluster nodes
+      ClusterNodeMin:
+        default: Minimum number of cluster nodes
+      ClusterNodeInstanceType:
+        default: Cluster node instance type
+      ClusterNodeVolumeSize:
+        default: Cluster node instance volume size
+      CustomDnsName:
+        default: Existing DNS name
+      DBInstanceClass:
+        default: Database instance class
+      DBIops:
+        default: RDS Provisioned IOPS
+      DBMasterUserPassword:
+        default: Master (admin) password *
+      DBMaxIdle:
+        default: DB Maximum Idle
+      DBMaxWaitMillis:
+        default: DB Maximum Wait
+      DBMinEvictableIdleTimeMillis:
+        default: DB Minimum Evictable Idle Time
+      DBMinIdle:
+        default: DB Minimum Idle Connections
+      DBMultiAZ:
+        default: Enable RDS Multi-AZ deployment
+      DBPassword:
+        default: Application user database password *
+      DBPoolMaxSize:
+        default: DB Pool Maximum Size
+      DBPoolMinSize:
+        default: DB Pool Minimum Size
+      DBRemoveAbandoned:
+        default: DB Remove Abandoned?
+      DBRemoveAbandonedTimeout:
+        default: DB Remove Abandoned Timeout
+      DBStorage:
+        default: Database storage
+      DBStorageEncrypted:
+        default: Database encryption
+      DBStorageType:
+        default: Database storage type
+      DBTestOnBorrow:
+        default: DB Test On Borrow?
+      DBTestWhileIdle:
+        default: DB Test While Idle?
+      DBTimeBetweenEvictionRunsMillis:
+        default: DB Time Between Eviction Runs
+      DeploymentAutomationRepository:
+        default: Deployment Automation Git Repository URL
+      DeploymentAutomationBranch:
+        default: Deployment Automation Branch
+      DeploymentAutomationPlaybook:
+        default: The Ansible playbook to invoke to initialize the instance
+      DeploymentAutomationKeyName:
+        default: SSH keyname to use with the repository
+      DeploymentAutomationCustomParams:
+        default: Custom command-line parameters for Ansible
+      ExportPrefix:
+        default: ASI identifier
+      HostedZone:
+        default: Route 53 Hosted Zone
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
+      CrowdVersion:
+        default: Version *
+      JvmHeapOverride:
+        default: JVM Heap Size Override
+      KeyPairName:
+        default: SSH Key Pair Name
+      MailEnabled:
+        default: Enable App to Process Email
+      PrivateSubnet1CIDR:
+        default: AZ1 private IP address block
+      PrivateSubnet2CIDR:
+        default: AZ2 private IP address block
+      PublicSubnet1CIDR:
+        default: AZ1 public IP address block
+      PublicSubnet2CIDR:
+        default: AZ2 public IP address block
+      SSLCertificateARN:
+        default: SSL Certificate ARN
+      TomcatAcceptCount:
+        default: Tomcat Accept Count
+      TomcatConnectionTimeout:
+        default: Tomcat Connection Timeout
+      TomcatContextPath:
+        default: Tomcat Context Path
+      TomcatDefaultConnectorPort:
+        default: Tomcat Default Connector Port
+      TomcatEnableLookups:
+        default: Tomcat Enable DNS Lookups
+      TomcatMaxThreads:
+        default: Tomcat Maximum Threads
+      TomcatMinSpareThreads:
+        default: Tomcat Minimum Spare Threads
+      TomcatProtocol:
+        default: Tomcat Protocol
+      TomcatRedirectPort:
+        default: Tomcat Redirect Port
+
+      QSS3BucketName:
+        default: Quick Start S3 Bucket Name
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
+
+      VPCCIDR:
+        default: IP address block for the VPC
+
+Parameters:
+  # Crowd DC template parameters
+  CatalinaOpts:
+    Default: ''
+    Description: Pass in any additional jvm options to tune Catalina
+    Type: String
+  CloudWatchIntegration:
+    Default: "Metrics and Logs"
+    Type: String
+    Description: "Enables CloudWatch metrics with or without log gathering. If cost is an issue, you can disable this altogether."
+    AllowedValues: ["Off", "Metrics Only", "Metrics and Logs"]
+    ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
+  ClusterNodeInstanceType:
+    Default: c5.xlarge
+    AllowedValues:
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.18xlarge
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.18xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - h1.2xlarge
+      - h1.4xlarge
+      - h1.8xlarge
+      - h1.16xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+      - i3.metal
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.12xlarge
+      - m5.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.12xlarge
+      - m5d.24xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.12xlarge
+      - r5.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.12xlarge
+      - r5d.24xlarge
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.xlarge
+      - x1e.2xlarge
+      - x1e.4xlarge
+      - x1e.8xlarge
+      - x1e.16xlarge
+      - x1e.32xlarge
+      - z1d.large
+      - z1d.xlarge
+      - z1d.2xlarge
+      - z1d.3xlarge
+      - z1d.6xlarge
+      - z1d.12xlarge
+    ConstraintDescription: Must be an EC2 instance type from the selection list
+    Description: Instance type for the cluster application nodes.
+    Type: String
+  ClusterNodeMax:
+    Description: Maximum number of nodes in the cluster.
+    Default: 1
+    Type: Number
+  ClusterNodeMin:
+    Default: 1
+    Description: Set to 1 for new deployment. Can be updated post launch.
+    Type: Number
+  ClusterNodeVolumeSize:
+    Default: 50
+    Description: Size of cluster node root volume in Gb (note - size based upon Application indexes x 4)
+    Type: Number
+  CustomDnsName:
+    Default: ""
+    Description: 'Use custom existing DNS name for your Data Center instance. This will take precedence over HostedZone. Please note: you must own the domain and configure it to point at the load balancer.'
+    Type: String
+  DBInstanceClass:
+    Default: db.m4.large
+    AllowedValues:
+      - db.m5.large
+      - db.m5.xlarge
+      - db.m5.2xlarge
+      - db.m5.4xlarge
+      - db.m5.12xlarge
+      - db.m5.24xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r4.8xlarge
+      - db.r4.16xlarge
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.m4.16xlarge
+      - db.t3.medium
+      - db.t3.large
+      - db.t3.xlarge
+      - db.t3.2xlarge
+      - db.t2.medium
+      - db.t2.large
+      - db.t2.xlarge
+      - db.t2.2xlarge
+    ConstraintDescription: Must be a valid RDS instance class, from the selection list
+    Description: RDS instance type (must be r family if using Aurora).
+    Type: String
+  DBIops:
+    Default: 1000
+    ConstraintDescription: 'Must be in the range 1000 - 30000'
+    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00 (not used for Aurora).'
+    MaxValue: 30000
+    MinValue: 1000
+    Type: Number
+  DBMasterUserPassword:
+    AllowedPattern: >-
+      ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
+    ConstraintDescription: >-
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
+    MaxLength: 128
+    MinLength: 8
+    Type: String
+  DBMaxIdle:
+    Default: 20
+    Description: The maximum number of database connections that are allowed to remain idle in the pool
+    Type: String
+  DBMaxWaitMillis:
+    Default: 10000
+    Description: The length of time (in milliseconds) that Crowd is allowed to wait for a database connection to become available (while there are no free ones available in the pool), before returning an error
+    Type: String
+  DBMinEvictableIdleTimeMillis:
+    Default: 180000
+    Description: The minimum amount of time an object may sit idle in the database connection pool before it is eligible for eviction by the idle object eviction
+    Type: String
+  DBMinIdle:
+    Default: 10
+    Description: The minimum number of idle database connections that are kept open at any time
+    Type: String
+  DBMultiAZ:
+    Description: Whether to provision a multi-AZ RDS instance.
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Type: String
+  DBPassword:
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    MinLength: 8
+    MaxLength: 128
+    NoEcho: true
+    Type: String
+  DBPoolMaxSize:
+    Default: 20
+    Description: The maximum number of database connections that can be opened at any time
+    Type: String
+  DBPoolMinSize:
+    Default: 20
+    Description: The minimum number of idle database connections that are kept open at any time
+    Type: String
+  DBRemoveAbandoned:
+    Default: true
+    Description: Flag to remove abandoned database connections if they exceed the Removed Abandoned Timeout
+    Type: String
+  DBRemoveAbandonedTimeout:
+    Default: 60
+    Description: The length of time (in seconds) that a database connection can be idle before it is considered abandoned
+    Type: String
+  DBStorage:
+    Default: 200
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144 (not used for Aurora).
+    Type: Number
+  DBStorageEncrypted:
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: Whether or not to encrypt the database
+    Type: String
+  DBStorageType:
+    Default: General Purpose (SSD)
+    AllowedValues:
+      - General Purpose (SSD)
+      - Provisioned IOPS
+    ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
+    Description: Database storage type (not used for Aurora).
+    Type: String
+  DBTestOnBorrow:
+    Default: false
+    Description: Tests if the database connection is valid when it is borrowed from the database connection pool by Crowd
+    Type: String
+  DBTestWhileIdle:
+    Default: true
+    Description: Periodically tests if the database connection is valid when it is idle
+    Type: String
+  DBTimeBetweenEvictionRunsMillis:
+    Default: 60000
+    Description: The number of milliseconds to sleep between runs of the idle object eviction thread. When non-positive, no idle object eviction thread will be run
+    Type: String
+  DeploymentAutomationRepository:
+    Default: "https://bitbucket.org/atlassian/dc-deployments-automation.git"
+    Type: String
+    Description: The deployment automation repository to use for per-node initialization. Leave this as default unless you have customizations.
+  DeploymentAutomationBranch:
+    Default: "master"
+    Type: String
+    Description: The deployment automation repository branch to pull from.
+  DeploymentAutomationPlaybook:
+    Default: "aws_crowd_dc_node.yml"
+    Type: String
+    Description: The Ansible playbook to invoke to initialise the Crowd node on first start.
+  DeploymentAutomationCustomParams:
+    Default: ""
+    Type: String
+    Description: Additional command-line options for the `ansible-playbook` command. See https://bitbucket.org/atlassian/dc-deployments-automation/src/master/README.md for more information about overriding parameters. (Optional)
+  DeploymentAutomationKeyName:
+    Default: ""
+    Type: String
+    Description: Named Key Pair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
+  ExportPrefix:
+    Default: 'ATL-'
+    Description:
+      Identifier used in all variables (VPCID, SubnetIDs, KeyName) exported from this deployment's Atlassian Standard Infrastructure. Use different identifiers if you're deploying multiple Atlassian Standard Infrastructures in the same AWS region.
+    Type: String
+  HostedZone:
+    Default: ''
+    ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
+    Description: The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames
+    Type: String
+  CrowdVersion:
+    Default: 4.0.0
+    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
+    ConstraintDescription: Must be a valid version number or 'latest'; for example, 4.0.0 for Crowd Software.
+    Description: The version of Crowd Software to install. Find valid versions at https://confluence.atlassian.com/crowd/crowd-4-0-release-notes-994320250.html (Crowd Software) or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
+    Type: String
+  JvmHeapOverride:
+    Default: ''
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
+  KeyPairName:
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
+    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Type: List<AWS::EC2::Keypair>
+    Default: ''
+  MailEnabled:
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Default: true
+    Description: Enable mail processing and sending
+    Type: String
+  SSLCertificateARN:
+    Default: ''
+    Description: "Amazon Resource Name (ARN) of your SSL certificate. Supplying this will automatically enable HTTPS on the product and load balancer, configured to use the corresponding certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you’ll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it’s successfully created."
+    MinLength: 0
+    MaxLength: 90
+    Type: String
+  TomcatAcceptCount:
+    Default: 10
+    Description: The maximum queue length for incoming connection requests when all possible request processing threads are in use
+    Type: String
+  TomcatConnectionTimeout:
+    Default: 20000
+    Description: The number of milliseconds this Connector will wait, after accepting a connection, for the request URI line to be presented
+    Type: String
+  TomcatContextPath:
+    Default: ''
+    AllowedPattern: '^(\/[A-z_\-0-9\.]+)?$'
+    Description: The context path of this web application, which is matched against the beginning of each request URI to select the appropriate web application for processing. If used, must include leading "/"
+    Type: String
+  TomcatDefaultConnectorPort:
+    Default: 8080
+    Description: The port on which to serve the application
+    Type: String
+  TomcatEnableLookups:
+    Default: false
+    Description: Set to true if you want calls to request.getRemoteHost() to perform DNS lookups in order to return the actual host name of the remote client
+    Type: String
+  TomcatMaxThreads:
+    Default: 200
+    Description: The maximum number of request processing threads to be created by this Connector, which therefore determines the maximum number of simultaneous requests that can be handled
+    Type: String
+  TomcatMinSpareThreads:
+    Default: 10
+    Description: The minimum number of threads always kept running
+    Type: String
+  TomcatProtocol:
+    Default: 'HTTP/1.1'
+    Description: Sets the protocol to handle incoming traffic
+    Type: String
+  TomcatRedirectPort:
+    Default: 8443
+    Description: The port number for Catalina to use when automatically redirecting a non-SSL connector actioning a redirect to a SSL URI
+    Type: String
+
+  # VPC parameters
+  AccessCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block allowed to access the Atlassian product. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
+    Type: String
+  AvailabilityZones:
+    Description: 'List of Availability Zones to use for the subnets in the VPC. Note: You must specify 2 AZs here;
+      if more are specified only the first 2 will be used.'
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  PrivateSubnet1CIDR:
+    Default: 10.0.0.0/19
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR block for private subnet 1 located in Availability Zone 1.
+    Type: String
+  PrivateSubnet2CIDR:
+    Default: 10.0.32.0/19
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR block for private subnet 2 located in Availability Zone 2.
+    Type: String
+  PublicSubnet1CIDR:
+    Default: 10.0.128.0/20
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone 1
+    Type: String
+  PublicSubnet2CIDR:
+    Default: 10.0.144.0/20
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone 2
+    Type: String
+  QSS3BucketName:
+    Default: 'aws-quickstart'
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
+      (-).
+    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
+      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    Default: 'quickstart-atlassian-crowd/'
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), and forward slash (/).
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+  VPCCIDR:
+    Default: 10.0.0.0/16
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the VPC
+    Type: String
+
+Conditions:
+  UseDatabaseEncryption:
+    !Equals [!Ref DBStorageEncrypted, true]
+  GovCloudCondition:
+    !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+
+Resources:
+  VPCStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-vpc-for-atlassian-services.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AccessCIDR: !Ref 'AccessCIDR'
+        AvailabilityZones: !Join
+          - ','
+          - !Ref 'AvailabilityZones'
+        ExportPrefix: !Ref 'ExportPrefix'
+        KeyPairName: !Ref 'KeyPairName'
+        PrivateSubnet1CIDR: !Ref 'PrivateSubnet1CIDR'
+        PrivateSubnet2CIDR: !Ref 'PrivateSubnet2CIDR'
+        PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
+        PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
+        VPCCIDR: !Ref 'VPCCIDR'
+
+  CrowdDCStack:
+    DependsOn: VPCStack
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart-crowd-dc.template.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      Parameters:
+        CatalinaOpts: !Ref 'CatalinaOpts'
+        CidrBlock: !Ref 'AccessCIDR'
+        CloudWatchIntegration: !Ref 'CloudWatchIntegration'
+        ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'
+        ClusterNodeMax: !Ref 'ClusterNodeMax'
+        ClusterNodeMin: !Ref 'ClusterNodeMin'
+        ClusterNodeVolumeSize: !Ref 'ClusterNodeVolumeSize'
+        CustomDnsName: !Ref 'CustomDnsName'
+        DBInstanceClass: !Ref 'DBInstanceClass'
+        DBIops: !Ref 'DBIops'
+        DBMasterUserPassword: !Ref 'DBMasterUserPassword'
+        DBMaxIdle: !Ref 'DBMaxIdle'
+        DBMaxWaitMillis: !Ref 'DBMaxWaitMillis'
+        DBMinEvictableIdleTimeMillis: !Ref 'DBMinEvictableIdleTimeMillis'
+        DBMinIdle: !Ref 'DBMinIdle'
+        DBMultiAZ: !Ref 'DBMultiAZ'
+        DBPassword: !Ref 'DBPassword'
+        DBPoolMaxSize: !Ref 'DBPoolMaxSize'
+        DBPoolMinSize: !Ref 'DBPoolMinSize'
+        DBRemoveAbandoned: !Ref 'DBRemoveAbandoned'
+        DBRemoveAbandonedTimeout: !Ref 'DBRemoveAbandonedTimeout'
+        DBStorage: !Ref 'DBStorage'
+        DBStorageEncrypted: !Ref 'DBStorageEncrypted'
+        DBStorageType: !Ref 'DBStorageType'
+        DBTestOnBorrow: !Ref 'DBTestOnBorrow'
+        DBTestWhileIdle: !Ref 'DBTestWhileIdle'
+        DBTimeBetweenEvictionRunsMillis: !Ref 'DBTimeBetweenEvictionRunsMillis'
+        DeploymentAutomationRepository: !Ref 'DeploymentAutomationRepository'
+        DeploymentAutomationBranch: !Ref 'DeploymentAutomationBranch'
+        DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
+        DeploymentAutomationPlaybook: !Ref 'DeploymentAutomationPlaybook'
+        DeploymentAutomationCustomParams: !Ref 'DeploymentAutomationCustomParams'
+        ExportPrefix: !Ref 'ExportPrefix'
+        HostedZone: !Ref 'HostedZone'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
+        CrowdVersion: !Ref 'CrowdVersion'
+        JvmHeapOverride: !Ref 'JvmHeapOverride'
+        KeyPairName: !Ref 'KeyPairName'
+        MailEnabled: !Ref 'MailEnabled'
+        QSS3BucketName: !Ref 'QSS3BucketName'
+        QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
+        SSLCertificateARN: !Ref 'SSLCertificateARN'
+        TomcatAcceptCount: !Ref 'TomcatAcceptCount'
+        TomcatConnectionTimeout: !Ref 'TomcatConnectionTimeout'
+        TomcatContextPath: !Ref 'TomcatContextPath'
+        TomcatDefaultConnectorPort: !Ref 'TomcatDefaultConnectorPort'
+        TomcatEnableLookups: !Ref 'TomcatEnableLookups'
+        TomcatMaxThreads: !Ref 'TomcatMaxThreads'
+        TomcatMinSpareThreads: !Ref 'TomcatMinSpareThreads'
+        TomcatProtocol: !Ref 'TomcatProtocol'
+        TomcatRedirectPort: !Ref 'TomcatRedirectPort'
+
+Outputs:
+  ServiceURL:
+    Description: The URL to access this Atlassian service
+    Value: !GetAtt 'CrowdDCStack.Outputs.ServiceURL'
+  LoadBalancerURL:
+    Description: The Load Balancer URL
+    Value: !GetAtt 'CrowdDCStack.Outputs.LoadBalancerURL'
+  BastionIP:
+    Description: Bastion node IP (use as a jumpbox to connect to the nodes)
+    Value: !GetAtt 'VPCStack.Outputs.BastionPubIp'
+  SGname:
+    Description: The name of the SecurityGroup
+    Value: !GetAtt 'CrowdDCStack.Outputs.SGname'
+  DBEndpointAddress:
+    Description: The Database Connection String
+    Value: !GetAtt 'CrowdDCStack.Outputs.DBEndpointAddress'
+  DBEncryptionKey:
+    Condition: UseDatabaseEncryption
+    Description: The alias of the encryption key created for RDS
+    Value: !GetAtt 'CrowdDCStack.Outputs.DBEncryptionKey'
+  EFSCname:
+    Description: The cname of the EFS
+    Value: !GetAtt 'CrowdDCStack.Outputs.EFSCname'

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -1,0 +1,1449 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Atlassian Crowd Data Center QS(0037)
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Crowd setup
+        Parameters:
+          - CrowdVersion
+      - Label:
+          default: Cluster nodes
+        Parameters:
+          - CloudWatchIntegration
+          - ClusterNodeInstanceType
+          - ClusterNodeMax
+          - ClusterNodeMin
+          - ClusterNodeVolumeSize
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationCustomParams
+          - DeploymentAutomationKeyName
+      - Label:
+          default: Database
+        Parameters:
+          - DBInstanceClass
+          - DBIops
+          - DBMasterUserPassword
+          - DBMultiAZ
+          - DBPassword
+          - DBStorage
+          - DBStorageEncrypted
+          - DBStorageType
+      - Label:
+          default: Networking
+        Parameters:
+          - InternetFacingLoadBalancer
+          - CidrBlock
+          - KeyPairName
+          - SSLCertificateARN
+      - Label:
+          default: DNS (Optional)
+        Parameters:
+          - CustomDnsName
+          - HostedZone
+      - Label:
+          default: Application Tuning (Optional)
+        Parameters:
+          - TomcatContextPath
+          - CatalinaOpts
+          - JvmHeapOverride
+          - DBPoolMaxSize
+          - DBPoolMinSize
+          - DBMaxIdle
+          - DBMaxWaitMillis
+          - DBMinEvictableIdleTimeMillis
+          - DBMinIdle
+          - DBRemoveAbandoned
+          - DBRemoveAbandonedTimeout
+          - DBTestOnBorrow
+          - DBTestWhileIdle
+          - DBTimeBetweenEvictionRunsMillis
+          - MailEnabled
+          - TomcatAcceptCount
+          - TomcatConnectionTimeout
+          - TomcatDefaultConnectorPort
+          - TomcatEnableLookups
+          - TomcatMaxThreads
+          - TomcatMinSpareThreads
+          - TomcatProtocol
+          - TomcatRedirectPort
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+          - ExportPrefix
+
+    ParameterLabels:
+      CatalinaOpts:
+        default: Catalina options
+      CidrBlock:
+        default: Permitted IP range
+      CloudWatchIntegration:
+        default: Enable CloudWatch integration
+      ClusterNodeMax:
+        default: Maximum number of cluster nodes
+      ClusterNodeMin:
+        default: Minimum number of cluster nodes
+      ClusterNodeInstanceType:
+        default: Cluster node instance type
+      ClusterNodeVolumeSize:
+        default: Cluster node instance volume size
+      CustomDnsName:
+        default: Existing DNS name
+      DBInstanceClass:
+        default: Database instance class
+      DBIops:
+        default: RDS Provisioned IOPS
+      DBMasterUserPassword:
+        default: Master (admin) password *
+      DBMaxIdle:
+        default: DB Maximum Idle
+      DBMaxWaitMillis:
+        default: DB Maximum Wait
+      DBMinEvictableIdleTimeMillis:
+        default: DB Minimum Evictable Idle Time
+      DBMinIdle:
+        default: DB Minimum Idle Connections
+      DBMultiAZ:
+        default: Enable RDS Multi-AZ deployment
+      DBPassword:
+        default: Application user database password *
+      DBPoolMaxSize:
+        default: DB Pool Maximum Size
+      DBPoolMinSize:
+        default: DB Pool Minimum Size
+      DBRemoveAbandoned:
+        default: DB Remove Abandoned?
+      DBRemoveAbandonedTimeout:
+        default: DB Remove Abandoned Timeout
+      DBStorage:
+        default: Database storage
+      DBStorageEncrypted:
+        default: Database encryption
+      DBStorageType:
+        default: Database storage type
+      DBTestOnBorrow:
+        default: DB Test On Borrow?
+      DBTestWhileIdle:
+        default: DB Test While Idle?
+      DBTimeBetweenEvictionRunsMillis:
+        default: DB Time Between Eviction Runs
+      DeploymentAutomationRepository:
+        default: Deployment Automation Git Repository URL
+      DeploymentAutomationBranch:
+        default: Deployment Automation Branch
+      DeploymentAutomationPlaybook:
+        default: The Ansible playbook to invoke to initialize the instance
+      DeploymentAutomationKeyName:
+        default: SSH keyname to use with the repository
+      DeploymentAutomationCustomParams:
+        default: Custom command-line parameters for Ansible
+      ExportPrefix:
+        default: ASI identifier
+      HostedZone:
+        default: Route 53 Hosted Zone
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
+      CrowdVersion:
+        default: Version *
+      JvmHeapOverride:
+        default: JVM Heap Size Override
+      KeyPairName:
+        default: SSH Key Pair Name
+      MailEnabled:
+        default: Enable App to Process Email
+      SSLCertificateARN:
+        default: SSL Certificate ARN
+      TomcatAcceptCount:
+        default: Tomcat Accept Count
+      TomcatConnectionTimeout:
+        default: Tomcat Connection Timeout
+      TomcatContextPath:
+        default: Tomcat Context Path
+      TomcatDefaultConnectorPort:
+        default: Tomcat Default Connector Port
+      TomcatEnableLookups:
+        default: Tomcat Enable DNS Lookups
+      TomcatMaxThreads:
+        default: Tomcat Maximum Threads
+      TomcatMinSpareThreads:
+        default: Tomcat Minimum Spare Threads
+      TomcatProtocol:
+        default: Tomcat Protocol
+      TomcatRedirectPort:
+        default: Tomcat Redirect Port
+      QSS3BucketName:
+        default: Quick Start S3 Bucket Name
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
+
+Parameters:
+  CatalinaOpts:
+    Default: ''
+    Description: Pass in any additional jvm options to tune Catalina
+    Type: String
+  CidrBlock:
+    AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
+    ConstraintDescription: Must be a valid IP CIDR range of the form x.x.x.x/x.
+    Description: CIDR Block allowed to access the Atlassian product. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
+    Type: String
+    MinLength: 9
+    MaxLength: 18
+  CloudWatchIntegration:
+    Default: "Metrics and Logs"
+    Type: String
+    Description: "Enables CloudWatch metrics with or without log gathering. If cost is an issue, you can disable this altogether."
+    AllowedValues: ["Off", "Metrics Only", "Metrics and Logs"]
+    ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
+  ClusterNodeInstanceType:
+    Default: c5.xlarge
+    AllowedValues:
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.18xlarge
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.18xlarge
+      - d2.xlarge
+      - d2.2xlarge
+      - d2.4xlarge
+      - d2.8xlarge
+      - h1.2xlarge
+      - h1.4xlarge
+      - h1.8xlarge
+      - h1.16xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+      - i3.metal
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.12xlarge
+      - m5.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.12xlarge
+      - m5d.24xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.12xlarge
+      - r5.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.12xlarge
+      - r5d.24xlarge
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - x1e.xlarge
+      - x1e.2xlarge
+      - x1e.4xlarge
+      - x1e.8xlarge
+      - x1e.16xlarge
+      - x1e.32xlarge
+      - z1d.large
+      - z1d.xlarge
+      - z1d.2xlarge
+      - z1d.3xlarge
+      - z1d.6xlarge
+      - z1d.12xlarge
+    ConstraintDescription: Must be an EC2 instance type from the selection list
+    Description: Instance type for the cluster application nodes.
+    Type: String
+  ClusterNodeMax:
+    Description: Maximum number of nodes in the cluster.
+    Default: 1
+    Type: Number
+  ClusterNodeMin:
+    Default: 1
+    Description: Set to 1 for new deployment. Can be updated post launch.
+    Type: Number
+  ClusterNodeVolumeSize:
+    Default: 50
+    Description: Size of cluster node root volume in Gb (note - size based upon Application indexes x 4)
+    Type: Number
+  CustomDnsName:
+    Default: ""
+    Description: 'Use custom existing DNS name for your Data Center instance. This will take precedence over HostedZone. Please note: you must own the domain and configure it to point at the load balancer.'
+    Type: String
+  DBInstanceClass:
+    Default: db.m4.large
+    AllowedValues:
+      - db.m5.large
+      - db.m5.xlarge
+      - db.m5.2xlarge
+      - db.m5.4xlarge
+      - db.m5.12xlarge
+      - db.m5.24xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r4.8xlarge
+      - db.r4.16xlarge
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.m4.16xlarge
+      - db.t3.medium
+      - db.t3.large
+      - db.t3.xlarge
+      - db.t3.2xlarge
+      - db.t2.medium
+      - db.t2.large
+      - db.t2.xlarge
+      - db.t2.2xlarge
+    ConstraintDescription: Must be a valid RDS instance class, from the selection list
+    Description: RDS instance type (must be r family if using Aurora).
+    Type: String
+  DBIops:
+    Default: 1000
+    ConstraintDescription: 'Must be in the range 1000 - 30000'
+    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00 (not used for Aurora).'
+    MaxValue: 30000
+    MinValue: 1000
+    Type: Number
+  DBMasterUserPassword:
+    AllowedPattern: >-
+      ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?!.*[@/"']).*$
+    ConstraintDescription: >-
+      Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
+    MaxLength: 128
+    MinLength: 8
+    Type: String
+  DBMaxIdle:
+    Default: 20
+    Description: The maximum number of database connections that are allowed to remain idle in the pool
+    Type: String
+  DBMaxWaitMillis:
+    Default: 10000
+    Description: The length of time (in milliseconds) that Crowd is allowed to wait for a database connection to become available (while there are no free ones available in the pool), before returning an error
+    Type: String
+  DBMinEvictableIdleTimeMillis:
+    Default: 180000
+    Description: The minimum amount of time an object may sit idle in the database connection pool before it is eligible for eviction by the idle object eviction
+    Type: String
+  DBMinIdle:
+    Default: 10
+    Description: The minimum number of idle database connections that are kept open at any time
+    Type: String
+  DBMultiAZ:
+    Description: Whether to provision a multi-AZ RDS instance.
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Type: String
+  DBPassword:
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    MinLength: 8
+    MaxLength: 128
+    NoEcho: true
+    Type: String
+  DBPoolMaxSize:
+    Default: 20
+    Description: The maximum number of database connections that can be opened at any time
+    Type: String
+  DBPoolMinSize:
+    Default: 20
+    Description: The minimum number of idle database connections that are kept open at any time
+    Type: String
+  DBRemoveAbandoned:
+    Default: true
+    Description: Flag to remove abandoned database connections if they exceed the Removed Abandoned Timeout
+    Type: String
+  DBRemoveAbandonedTimeout:
+    Default: 60
+    Description: The length of time (in seconds) that a database connection can be idle before it is considered abandoned
+    Type: String
+  DBStorage:
+    Default: 20
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144 (not used for Aurora).
+    Type: Number
+  DBStorageEncrypted:
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: Whether to encrypt the database
+    Type: String
+  DBStorageType:
+    Default: General Purpose (SSD)
+    AllowedValues:
+      - General Purpose (SSD)
+      - Provisioned IOPS
+    ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
+    Description: Database storage type (not used for Aurora).
+    Type: String
+  DBTestOnBorrow:
+    Default: false
+    Description: Tests if the database connection is valid when it is borrowed from the database connection pool by Crowd
+    Type: String
+  DBTestWhileIdle:
+    Default: true
+    Description: Periodically tests if the database connection is valid when it is idle
+    Type: String
+  DBTimeBetweenEvictionRunsMillis:
+    Default: 60000
+    Description: The number of milliseconds to sleep between runs of the idle object eviction thread. When non-positive, no idle object eviction thread will be run
+    Type: String
+  DeploymentAutomationRepository:
+    Default: "https://bitbucket.org/atlassian/dc-deployments-automation.git"
+    Type: String
+    Description: The deployment automation repository to use for per-node initialization. Leave this as default unless you have customizations.
+  DeploymentAutomationBranch:
+    Default: "master"
+    Type: String
+    Description: The deployment automation repository branch to pull from.
+  DeploymentAutomationPlaybook:
+    Default: "aws_crowd_dc_node.yml"
+    Type: String
+    Description: The Ansible playbook to invoke to initialize the Crowd node on first start.
+  DeploymentAutomationCustomParams:
+    Default: ""
+    Type: String
+    Description: Additional command-line options for the `ansible-playbook` command. See https://bitbucket.org/atlassian/dc-deployments-automation/src/master/README.md for more information about overriding parameters. (Optional)
+  DeploymentAutomationKeyName:
+    Default: ""
+    Type: String
+    Description: Named Key Pair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
+  ExportPrefix:
+    Default: 'ATL-'
+    Description:
+      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy Crowd.
+    Type: String
+  HostedZone:
+    Default: ''
+    ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
+    Description: The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames
+    Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
+  CrowdVersion:
+    Default: 4.0.0
+    AllowedPattern: '(\d+\.\d+\.\d+(-?.*))|(latest)'
+    ConstraintDescription: Must be a valid version number or 'latest'; for example, 4.0.0 for Crowd Software.
+    Description: The version of Crowd Software to install. Find valid versions at https://confluence.atlassian.com/crowd/crowd-4-0-release-notes-994320250.html (Crowd Software) or https://confluence.atlassian.com/x/XM2EO (Atlassian Enterprise Releases).
+    Type: String
+  JvmHeapOverride:
+    Default: ''
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
+  KeyPairName:
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
+    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
+    Type: String
+    Default: ''
+  MailEnabled:
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Must be 'true' or 'false'.
+    Default: true
+    Description: Enable mail processing and sending
+    Type: String
+  SSLCertificateARN:
+    Default: ''
+    Description: "Amazon Resource Name (ARN) of your SSL certificate. Supplying this will automatically enable HTTPS on the product and load balancer, configured to use the corresponding certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you’ll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it’s successfully created."
+    MinLength: 0
+    MaxLength: 90
+    Type: String
+  TomcatAcceptCount:
+    Default: 10
+    Description: The maximum queue length for incoming connection requests when all possible request processing threads are in use
+    Type: String
+  TomcatConnectionTimeout:
+    Default: 20000
+    Description: The number of milliseconds this Connector will wait, after accepting a connection, for the request URI line to be presented
+    Type: String
+  TomcatContextPath:
+    Default: ''
+    AllowedPattern: '^(\/[A-z_\-0-9\.]+)?$'
+    Description: The context path of this web application, which is matched against the beginning of each request URI to select the appropriate web application for processing. If used, must include leading "/"
+    Type: String
+  TomcatDefaultConnectorPort:
+    Default: 8080
+    Description: The port on which to serve the application
+    Type: String
+  TomcatEnableLookups:
+    Default: false
+    Description: Set to true if you want calls to request.getRemoteHost() to perform DNS lookups in order to return the actual host name of the remote client
+    Type: String
+  TomcatMaxThreads:
+    Default: 200
+    Description: The maximum number of request processing threads to be created by this Connector, which therefore determines the maximum number of simultaneous requests that can be handled
+    Type: String
+  TomcatMinSpareThreads:
+    Default: 10
+    Description: The minimum number of threads always kept running
+    Type: String
+  TomcatProtocol:
+    Default: 'HTTP/1.1'
+    Description: Sets the protocol to handle incoming traffic
+    Type: String
+  TomcatRedirectPort:
+    Default: 8443
+    Description: The port number for Catalina to use when automatically redirecting a non-SSL connector actioning a redirect to a SSL URI
+    Type: String
+  QSS3BucketName:
+    Default: 'aws-quickstart'
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
+      (-).
+    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
+      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    Default: 'quickstart-atlassian-crowd/'
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), and forward slash (/).
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+
+Conditions:
+  DisableMail:
+    !Not [!Equals [!Ref MailEnabled, true]]
+  EnableCloudWatch:
+    !Not [!Equals [!Ref CloudWatchIntegration, 'Off']]
+  EnableCloudWatchLogs:
+    !Equals [!Ref CloudWatchIntegration, 'Metrics and Logs']
+  DoSSL:
+    !Not [!Equals [!Ref SSLCertificateARN, '']]
+  KeyProvided:
+    !Not [!Equals [!Ref KeyPairName, '']]
+  OverrideHeap:
+    !Not [!Equals [!Ref JvmHeapOverride, '']]
+  UseContextPath:
+    !Not [!Equals [!Ref TomcatContextPath, '']]
+  UseCustomDnsName:
+    !Not [!Equals [!Ref CustomDnsName, '']]
+  UseDatabaseEncryption:
+    !Equals [!Ref DBStorageEncrypted, true]
+  UseHostedZone:
+    !Not [!Equals [!Ref HostedZone, '']]
+  UsePublicIp:
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
+  GovCloudCondition:
+    !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+Mappings:
+  AWSInstanceType2Arch:
+    c4.large:
+      Arch: HVM64
+      Jvmheap: 2304m
+    c4.xlarge:
+      Arch: HVM64
+      Jvmheap: 4608m
+    c4.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c4.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c4.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5.large:
+      Arch: HVM64
+      Jvmheap: 2048m
+    c5.xlarge:
+      Arch: HVM64
+      Jvmheap: 5120m
+    c5.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5.9xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5.18xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5d.large:
+      Arch: HVM64
+      Jvmheap: 2048m
+    c5d.xlarge:
+      Arch: HVM64
+      Jvmheap: 5120m
+    c5d.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5d.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5d.9xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    c5d.18xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    d2.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    d2.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    d2.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    d2.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    h1.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    h1.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    h1.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    h1.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.large:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    i3.metal:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m4.large:
+      Arch: HVM64
+      Jvmheap: 5120m
+    m4.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m4.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m4.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m4.10xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m4.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5.large:
+      Arch: HVM64
+      Jvmheap: 5120m
+    m5.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5.12xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5.24xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5d.large:
+      Arch: HVM64
+      Jvmheap: 5120m
+    m5d.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5d.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5d.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5d.12xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    m5d.24xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.large:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r4.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.large:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.12xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5.24xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.large:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.12xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    r5d.24xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    t2.medium:
+      Arch: HVM64
+      Jvmheap: 2048m
+    t2.large:
+      Arch: HVM64
+      Jvmheap: 5120m
+    t2.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    t2.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    t3.medium:
+      Arch: HVM64
+      Jvmheap: 2048m
+    t3.large:
+      Arch: HVM64
+      Jvmheap: 5120m
+    t3.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    t3.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1.32xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.4xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.8xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.16xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    x1e.32xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.large:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.2xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.3xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.6xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+    z1d.12xlarge:
+      Arch: HVM64
+      Jvmheap: 12288m
+
+  AWSRegionArch2AMI:
+    ap-northeast-1:
+      HVM64: ami-00d101850e971728d
+    ap-northeast-2:
+      HVM64: ami-08ab3f7e72215fe91
+    ap-south-1:
+      HVM64: ami-00e782930f1c3dbc7
+    ap-southeast-1:
+      HVM64: ami-0b5a47f8865280111
+    ap-southeast-2:
+      HVM64: ami-0fb7513bcdc525c3b
+    ca-central-1:
+      HVM64: ami-08a9b721ecc5b0a53
+    eu-central-1:
+      HVM64: ami-0ebe657bc328d4e82
+    eu-north-1:
+      HVM64: ami-1fb13961
+    eu-west-1:
+      HVM64: ami-030dbca661d402413
+    eu-west-2:
+      HVM64: ami-0009a33f033d8b7b6
+    eu-west-3:
+      HVM64: ami-0ebb3a801d5fb8b9b
+    sa-east-1:
+      HVM64: ami-058141e091292ecf0
+    us-east-1:
+      HVM64: ami-0c6b1d09930fac512
+    us-east-2:
+      HVM64: ami-0ebbf2179e615c338
+    us-west-1:
+      HVM64: ami-015954d5e5548d13b
+    us-west-2:
+      HVM64: ami-0cb72367e98845d43
+    us-gov-west-1:
+      HVM64: ami-e9a9d388
+    us-gov-east-1:
+      HVM64: ami-a2d938d3
+
+Resources:
+  ClusterNodeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ec2.amazonaws.com]
+            Action: ['sts:AssumeRole']
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Path: /
+      Policies:
+        - PolicyName: CrowdClusterNodePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - 'autoscaling:DescribeTags'
+                  - 'autoscaling:CreateOrUpdateTags'
+                  - 'ec2:CreateTags'
+                  - 'ec2:DescribeInstances'
+                  - 'ec2:DescribeTags'
+                  - 'route53:ListHostedZones'
+                  - 'route53:ListResourceRecordSet'
+                Effect: Allow
+                Resource: ['*']
+              - Action:
+                  - "route53:ChangeResourceRecordSets"
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:route53:::healthcheck/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::healthcheck/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::change/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::hostedzone/*'
+                  - !Sub 'arn:${AWS::Partition}:route53:::delegationset/*'
+  ClusterNodeInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles: [!Ref ClusterNodeRole]
+  # Crowd node config
+  ClusterNodeGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      DesiredCapacity: !Ref ClusterNodeMin
+      LaunchConfigurationName: !Ref ClusterNodeLaunchConfig
+      MaxSize: !Ref ClusterNodeMax
+      MinSize: !Ref ClusterNodeMin
+      TargetGroupARNs: [!Ref MainTargetGroup]
+      VPCZoneIdentifier: !Split
+        - ","
+        - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+      Tags:
+        - Key: Name
+          Value: !Sub ["${StackName} Crowd Node", {StackName: !Ref 'AWS::StackName'}]
+          PropagateAtLaunch: true
+        - Key: Cluster
+          Value: !Ref AWS::StackName
+          PropagateAtLaunch: true
+  ClusterNodeLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn:
+      - EFSMountAz1
+      - EFSMountAz2
+    Metadata:
+      Comment: ''
+      AWS::CloudFormation::Init:
+        config:
+          files:
+            /etc/atl:
+              mode: "000640"
+              owner: root
+              group: root
+              content:
+                'Fn::Join':
+                  - "\n"
+                  - - "ATL_PRODUCT_FAMILY=crowd"
+                    - "ATL_DB_DRIVER=org.postgresql.Driver"
+                    - "ATL_JDBC_DB_NAME=crowd"
+                    - "ATL_JDBC_USER=atlcrowd"
+                    - "ATL_JVM_OPTS='-XX:+ExplicitGCInvokesConcurrent -XX:ReservedCodeCacheSize=512M'"
+                    - "ATL_APP_DATA_MOUNT_ENABLED=false"
+                    - "ATL_ENABLED_PRODUCTS=Crowd"
+                    - "ATL_ENABLED_SHARED_HOMES="
+                    - "ATL_NGINX_ENABLED=false"
+                    - "ATL_POSTGRES_ENABLED=false"
+                    - "ATL_RELEASE_S3_BUCKET=atlassian-software"
+                    - "ATL_RELEASE_S3_PATH=releases"
+                    - "ATL_SSL_SELF_CERT_ENABLED=false"
+                    - ""
+                    - !Sub ["ATL_PRODUCT_VERSION=${ProductVersion}", ProductVersion: !Ref CrowdVersion]
+                    - !Sub ["ATL_EFS_ID=${ElasticFileSystem}", ElasticFileSystem: !Ref ElasticFileSystem]
+                    - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
+                    - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
+                    - !Sub ["ATL_CATALINA_OPTS=\"${CatalinaOpts} ${MailOpts}\"", { CatalinaOpts: !Ref CatalinaOpts, MailOpts: !If [DisableMail, '-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true', ''] }]
+                    - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Outputs.RDSEndPointAddress]
+                    - !Sub ["ATL_DB_MAXIDLE=${DBMaxIdle}", DBMaxIdle: !Ref DBMaxIdle]
+                    - !Sub ["ATL_DB_MAXWAITMILLIS=${DBMaxWaitMillis}", DBMaxWaitMillis: !Ref DBMaxWaitMillis]
+                    - !Sub ["ATL_DB_MINEVICTABLEIDLETIMEMILLIS=${DBMinEvictableIdleTimeMillis}", DBMinEvictableIdleTimeMillis: !Ref DBMinEvictableIdleTimeMillis]
+                    - !Sub ["ATL_DB_MINIDLE=${DBMinIdle}", DBMinIdle: !Ref DBMinIdle]
+                    - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                    - !Sub ["ATL_DB_POOLMAXSIZE=${DBPoolMaxSize}", DBPoolMaxSize: !Ref DBPoolMaxSize]
+                    - !Sub ["ATL_DB_POOLMINSIZE=${DBPoolMinSize}", DBPoolMinSize: !Ref DBPoolMinSize]
+                    - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Outputs.RDSEndPointPort]
+                    - !Sub ["ATL_DB_REMOVEABANDONED=${DBRemoveAbandoned}", DBRemoveAbandoned: !Ref DBRemoveAbandoned]
+                    - !Sub ["ATL_DB_REMOVEABANDONEDTIMEOUT=${DBRemoveAbandonedTimeout}", DBRemoveAbandonedTimeout: !Ref DBRemoveAbandonedTimeout]
+                    - !Sub ["ATL_DB_TESTONBORROW=${DBTestOnBorrow}", DBTestOnBorrow: !Ref DBTestOnBorrow]
+                    - !Sub ["ATL_DB_TESTWHILEIDLE=${DBTestWhileIdle}", DBTestWhileIdle: !Ref DBTestWhileIdle]
+                    - !Sub ["ATL_DB_TIMEBETWEENEVICTIONRUNSMILLIS=${DBTimeBetweenEvictionRunsMillis}", DBTimeBetweenEvictionRunsMillis: !Ref DBTimeBetweenEvictionRunsMillis]
+                    - !Sub ["ATL_HOSTEDZONE=${HostedZone}", HostedZone: !Ref HostedZone]
+                    - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
+                    - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/crowd?targetServerType=master", { DBEndpointAddress: !GetAtt DB.Outputs.RDSEndPointAddress, DBEndpointPort: !GetAtt DB.Outputs.RDSEndPointPort }]
+                    - !Sub ["ATL_JVM_HEAP=${AtlJvmHeap}", AtlJvmHeap: !If [OverrideHeap, !Ref 'JvmHeapOverride', !FindInMap [AWSInstanceType2Arch, !Ref ClusterNodeInstanceType, Jvmheap]]]
+                    - !Sub ["ATL_PROXY_NAME=${AtlProxyName}", AtlProxyName: !If [UseCustomDnsName, !Ref CustomDnsName, !If [UseHostedZone, !Ref LoadBalancerCname, !GetAtt LoadBalancer.DNSName]]]
+                    - !Sub ["ATL_TOMCAT_ACCEPTCOUNT=${TomcatAcceptCount}", TomcatAcceptCount: !Ref TomcatAcceptCount]
+                    - !Sub ["ATL_TOMCAT_CONNECTIONTIMEOUT=${TomcatConnectionTimeout}", TomcatConnectionTimeout: !Ref TomcatConnectionTimeout]
+                    - !Sub ["ATL_TOMCAT_CONTEXTPATH=${TomcatContextPath}", TomcatContextPath: !Ref TomcatContextPath]
+                    - !Sub ["ATL_TOMCAT_DEFAULTCONNECTORPORT=${TomcatDefaultConnectorPort}", TomcatDefaultConnectorPort: !Ref TomcatDefaultConnectorPort]
+                    - !Sub ["ATL_TOMCAT_ENABLELOOKUPS=${TomcatEnableLookups}", TomcatEnableLookups: !Ref TomcatEnableLookups]
+                    - !Sub ["ATL_TOMCAT_MAXTHREADS=${TomcatMaxThreads}", TomcatMaxThreads: !Ref TomcatMaxThreads]
+                    - !Sub ["ATL_TOMCAT_MINSPARETHREADS=${TomcatMinSpareThreads}", TomcatMinSpareThreads: !Ref TomcatMinSpareThreads]
+                    - !Sub ["ATL_TOMCAT_PROTOCOL=${TomcatProtocol}", TomcatProtocol: !Ref TomcatProtocol]
+                    - !Sub ["ATL_TOMCAT_PROXYPORT=${TomcatProxyPort}", TomcatProxyPort: !If [DoSSL, 443, 80]]
+                    - !Sub ["ATL_TOMCAT_REDIRECTPORT=${TomcatRedirectPort}", TomcatRedirectPort: !Ref TomcatRedirectPort]
+                    - !Sub ["ATL_TOMCAT_SCHEME=${TomcatScheme}", TomcatScheme: !If [DoSSL, https, http]]
+                    - !Sub ["ATL_TOMCAT_SECURE=${TomcatSecure}", TomcatSecure: !If [DoSSL, true, false]]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY=${DeployRepository}", DeployRepository: !Ref DeploymentAutomationRepository]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY_BRANCH=${DeployRepositoryBranch}", DeployRepositoryBranch: !Ref DeploymentAutomationBranch]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY_PLAYBOOK=${DeployRepositoryPlaybook}", DeployRepositoryPlaybook: !Ref DeploymentAutomationPlaybook]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY_KEYNAME=${DeployRepositoryKeyName}", DeployRepositoryKeyName: !Ref DeploymentAutomationKeyName]
+                    - !Sub ["ATL_DEPLOYMENT_REPOSITORY_CUSTOM_PARAMS='${DeployRepositoryCustomParams}'", DeployRepositoryCustomParams: !Ref DeploymentAutomationCustomParams]
+
+                    - !Sub ["ATL_AWS_ENABLE_CLOUDWATCH=${EnableCW}", EnableCW: !If [EnableCloudWatch, true, false]]
+                    - !Sub ["ATL_AWS_ENABLE_CLOUDWATCH_LOGS=${EnableCWLogs}", EnableCWLogs: !If [EnableCloudWatchLogs, true, false]]
+
+            /opt/atlassian/bin/clone_deployment_repo:
+              content: !Sub |
+                #!/bin/bash
+                key_location=/root/.ssh/deployment_repo_key
+                key_name="${DeploymentAutomationKeyName}"
+
+                yum install -y git
+                if [[ ! -z "$key_name" ]]; then
+                    # Ensure awscli is up to date
+                    yum install -y awscli jq
+                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0] .Value')
+                    echo -e "$key_val" > $key_location
+                    chmod 600 $key_location
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i $key_location"
+                else
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+                fi
+
+                git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
+              mode: "000750"
+              owner: root
+              group: root
+
+          commands:
+            070_create_atl_dir:
+              test: "test ! -d /opt/atlassian/"
+              command: mkdir -p /opt/atlassian
+              ignoreErrors: false
+            071_install_packages:
+              command: yum install -y git python-virtualenv
+              ignoreErrors: true
+            072_clone_atl_scripts:
+              test: "test ! -d /opt/atlassian/dc-deployments-automation/"
+              command: /opt/atlassian/bin/clone_deployment_repo
+              ignoreErrors: true
+            080_run_atl_init_node:
+              command: !Sub |
+                cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local ${DeploymentAutomationPlaybook} /var/log/ansible-bootstrap.log
+              ignoreErrors: true
+
+    Properties:
+      AssociatePublicIpAddress: false
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref ClusterNodeVolumeSize
+        - DeviceName: /dev/xvdf
+          NoDevice: true
+      KeyName: !If
+        - KeyProvided
+        - !Ref KeyPairName
+        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
+      IamInstanceProfile: !Ref ClusterNodeInstanceProfile
+      ImageId:
+        !FindInMap
+        - AWSRegionArch2AMI
+        - !Ref AWS::Region
+        - !FindInMap
+          - AWSInstanceType2Arch
+          - !Ref ClusterNodeInstanceType
+          - Arch
+      InstanceType: !Ref ClusterNodeInstanceType
+      SecurityGroups: [!Ref SecurityGroup]
+      UserData:
+        Fn::Base64:
+          !Join
+          - ""
+          -
+            - "#!/bin/bash -xe\n"
+            - "yum update -y aws-cfn-bootstrap\n"
+            - !Sub ["/opt/aws/bin/cfn-init -v --stack ${StackName}", {StackName: !Ref "AWS::StackName"}]
+            - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}\n", {Region: !Ref "AWS::Region"}]
+            - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", {StackName: !Ref "AWS::StackName"}]
+            - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}", {Region: !Ref "AWS::Region"}]
+  #Scaling policies to respond during resource usage spikes
+  ClusterNodeScaleUpPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref ClusterNodeGroup
+      Cooldown: '600'
+      ScalingAdjustment: 1
+  ClusterNodeScaleDownPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref ClusterNodeGroup
+      Cooldown: '600'
+      ScalingAdjustment: -1
+  #Scaling policy alarms
+  CPUAlarmHigh:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale up if CPU > 60% for 5 minutes
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 60
+      AlarmActions: [!Ref ClusterNodeScaleUpPolicy]
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: !Ref ClusterNodeGroup
+      ComparisonOperator: GreaterThanThreshold
+  CPUAlarmLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Scale down if CPU < 40% for 30 minutes
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 30
+      Threshold: 40
+      AlarmActions: [!Ref ClusterNodeScaleDownPolicy]
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: !Ref ClusterNodeGroup
+      ComparisonOperator: LessThanThreshold
+  # Elastic file system
+  ElasticFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      FileSystemTags:
+        - Key: Name
+          Value: !Join [' ', [!Ref 'AWS::StackName', 'cluster shared-files']]
+        - Key: Application
+          Value: !Ref AWS::StackId
+  EFSMountAz1:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref ElasticFileSystem
+      SecurityGroups: [!Ref SecurityGroup]
+      SubnetId: !Select
+        - 0
+        - !Split
+          - ","
+          - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+  EFSMountAz2:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref ElasticFileSystem
+      SecurityGroups: [!Ref SecurityGroup]
+      SubnetId: !Select
+        - 1
+        - !Split
+          - ","
+          - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+  EFSCname:
+    Type: AWS::Route53::RecordSet
+    Condition: UseHostedZone
+    Properties:
+      HostedZoneName: !Ref HostedZone
+      Comment: Route53 cname for the efs
+      Name: !If [ UseHostedZone, !Join ['.', [!Ref 'AWS::StackName', 'efs', !Ref 'HostedZone']], '']
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+        - !Join ['.', [!Ref ElasticFileSystem, 'efs', !Ref 'AWS::Region', 'amazonaws.com.']]
+  # Database
+  DB:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-database-for-atlassian-services.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      Parameters:
+        DatabaseImplementation: "PostgreSQL"
+        DBSecurityGroup: !Ref SecurityGroup
+        DBAutoMinorVersionUpgrade: "true"
+        DBBackupRetentionPeriod: "1"
+        DBInstanceClass: !Ref DBInstanceClass
+        DBIops: !Ref DBIops
+        DBMasterUserPassword: !Ref DBMasterUserPassword
+        DBMultiAZ: !Ref DBMultiAZ
+        DBAllocatedStorage: !Ref DBStorage
+        DBStorageEncrypted: !Ref DBStorageEncrypted
+        DBStorageType: !Ref DBStorageType
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+  DBCname:
+    Condition: UseHostedZone
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Ref HostedZone
+      Comment: Route53 cname for the RDS
+      Name: !Join ['.', [!Ref 'AWS::StackName', 'db', !Ref 'HostedZone']]
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+        - !GetAtt DB.Outputs.RDSEndPointAddress
+  # Loadbalancer
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: '3600'
+      Scheme: !If [UsePublicIp, 'internet-facing', 'internal']
+      SecurityGroups: [!Ref SecurityGroup]
+      Subnets: !Split
+        - ","
+        - Fn::ImportValue: !Sub "${ExportPrefix}PubNets"
+      Tags:
+        - Key: Name
+          Value: !Sub ["${StackName}-LoadBalancer", StackName: !Ref 'AWS::StackName']
+        - Key: Cluster
+          Value: !Ref AWS::StackName
+  LoadBalancerHTTPListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - !If
+          - DoSSL
+          - Type: redirect
+            RedirectConfig:
+              Protocol: HTTPS
+              Port: '443'
+              Host: '#{host}'
+              Path: '/#{path}'
+              Query: '#{query}'
+              StatusCode: HTTP_301
+          - Type: forward
+            TargetGroupArn: !Ref MainTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+  LoadBalancerHTTPSListener:
+    Condition: DoSSL
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref SSLCertificateARN
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref MainTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+  MainTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: !Ref TomcatDefaultConnectorPort
+      Protocol: HTTP
+      VpcId:
+        Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
+      HealthCheckIntervalSeconds: 20
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: '200'
+      HealthCheckPath: !If [UseContextPath, !Join ['', [!Ref 'TomcatContextPath', '/status']], '/status']
+      HealthCheckPort: !Ref TomcatDefaultConnectorPort
+      HealthCheckProtocol: HTTP
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: 'true'
+        - Key: stickiness.type
+          Value: lb_cookie
+        - Key: deregistration_delay.timeout_seconds
+          Value: '30'
+      Tags:
+        - Key: Name
+          Value: MainTargetGroup
+        - Key: Cluster
+          Value: !Ref AWS::StackName
+    DependsOn:
+      - LoadBalancer
+  LoadBalancerCname:
+    Condition: UseHostedZone
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Ref HostedZone
+      Comment: Route53 cname for the ALB
+      Name: !Join ['.', [!Ref "AWS::StackName", !Ref 'HostedZone']]
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+        - !GetAtt LoadBalancer.DNSName
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group allowing SSH and HTTP/HTTPS access
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !Ref CidrBlock
+      Tags:
+        - Key: Name
+          Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
+      VpcId:
+        Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: '-1'
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref SecurityGroup
+  EncryptionKey:
+    Condition: UseDatabaseEncryption
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: !Sub "${AWS::StackName}"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
+  EncryptionKeyAlias:
+    Condition: UseDatabaseEncryption
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}"
+      TargetKeyId: !Ref EncryptionKey
+
+  # Optional: Cloudwatch dashboard to be created when CloudWatch is enabled
+  CloudWatchDashboard:
+    DependsOn:
+      - DB
+    Condition: EnableCloudWatch
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-cloudwatch-dashboard.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      Parameters:
+        ProductStackName: !Sub "${AWS::StackName}"
+        ProductFamilyName: "crowd"
+        AsgToMonitor: !Ref ClusterNodeGroup
+
+Outputs:
+  ServiceURL:
+    Description: The URL to access this Atlassian service
+    Value: !If
+      - UseCustomDnsName
+      - !Sub
+        - "${HTTP}://${CustomDNSName}${ContextPath}"
+        - HTTP: !If [DoSSL, 'https', 'http']
+          CustomDNSName: !Ref CustomDnsName
+          ContextPath: !Ref TomcatContextPath
+      - !If
+        - UseHostedZone
+        - !Sub
+          - "${HTTP}://${LBCName}${ContextPath}"
+          - HTTP: !If [DoSSL, 'https', 'http']
+            LBCName: !Ref LoadBalancerCname
+            ContextPath: !Ref TomcatContextPath
+        - !Sub
+          - "${HTTP}://${LoadBalancerDNSName}${ContextPath}"
+          - HTTP: !If [DoSSL, 'https', 'http']
+            LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
+            ContextPath: !Ref TomcatContextPath
+  LoadBalancerURL:
+    Description: The Load Balancer URL
+    Value: !Sub
+      - "${HTTP}://${LoadBalancerDNSName}"
+      - HTTP: !If [DoSSL, 'https', 'http']
+        LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
+  SGname:
+    Description: The name of the SecurityGroup
+    Value: !Ref SecurityGroup
+    Export: {
+      Name: !Join ['', [!Ref 'AWS::StackName', '-SGname']]
+    }
+  DBEndpointAddress:
+    Description: The Database Connection String
+    Value: !GetAtt DB.Outputs.RDSEndPointAddress
+  DBEncryptionKey:
+    Condition: UseDatabaseEncryption
+    Description: The alias of the encryption key created for RDS
+    Value: !Ref EncryptionKeyAlias
+  EFSCname:
+    Description: The cname of the EFS
+    Value: !If
+      - UseHostedZone
+      - !Ref EFSCname
+      - !Ref ElasticFileSystem
+    Export: {
+      Name: !Join ['', [!Ref 'AWS::StackName', '-EFSCname']]
+    }
+  CloudWatchDashboardURL:
+    Description: CloudWatch monitoring dashboard URL
+    Value: !GetAtt CloudWatchDashboard.Outputs.Dashboard
+    Condition: EnableCloudWatch


### PR DESCRIPTION
*Issue number:*
[DCD-261: Create Crowd DC AWS Quickstart](https://bulldog.internal.atlassian.com/browse/DCD-261)

*Details:*
Due to the fact that the [underlying infrastructure that Crowd ](https://confluence.atlassian.com/enterprise/crowd-data-center-933084126.html)relies on is the same as that of [Jira's](https://confluence.atlassian.com/enterprise/jira-data-center-472219731.html), this Crowd DC AWS Quickstart is based on the [Jira Quickstart](https://github.com/atlassian/quickstart-atlassian-jira).

This template also includes the addition of an `AWS::AutoScaling::AutoScalingGroup` which will flex up and down based on an `AWS::CloudWatch::Alarm`, namely; `CPUAlarmHigh` and `CPUAlarmLow`. The configuration for these alarms is based on the same alarm config that [Confluence uses](https://github.com/atlassian/quickstart-atlassian-confluence/blob/develop/templates/quickstart-confluence-master.template.yaml).

Note: This template has been tested via CloudFormation and successfully deploys Crowd.