### PR TITLE
 DCD-948: Make Bastion host provisioning optional

### DIFF
--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -37,12 +37,16 @@ Metadata:
           - DBStorageEncrypted
           - DBStorageType
       - Label:
+          default: Bastion host provisioning
+        Parameters:
+          - BastionHostRequired
+          - KeyPairName
+      - Label:
           default: Networking
         Parameters:
           - AccessCIDR
           - AvailabilityZones
           - InternetFacingLoadBalancer
-          - KeyPairName
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
           - PublicSubnet1CIDR
@@ -131,6 +135,8 @@ Metadata:
         default: Version *
       JvmHeapOverride:
         default: JVM Heap Size Override
+      BastionHostRequired:
+          default: Deploy Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       MailEnabled:
@@ -434,10 +440,17 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to provision a Bastion host instance. If 'true', then you need to provide an EC2 Key Pair (otherwise, you won't be able to use the Bastion host to access Crowd instances).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances.
-    Type: AWS::EC2::KeyPair::KeyName
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
+    Type: String
     Default: ''
   MailEnabled:
     AllowedValues:
@@ -553,6 +566,11 @@ Conditions:
     !Equals [!Ref DBStorageEncrypted, true]
   GovCloudCondition:
     !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+  KeyProvided:
+    !Not [!Equals [!Ref KeyPairName, '']]
+  ProvisionBastion: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 
 Resources:
   VPCStack:
@@ -576,6 +594,7 @@ Resources:
         PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
         PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
         VPCCIDR: !Ref 'VPCCIDR'
+        BastionHostRequired: !Ref 'BastionHostRequired'
 
   CrowdDCStack:
     DependsOn: VPCStack
@@ -625,6 +644,7 @@ Resources:
         TomcatMinSpareThreads: !Ref 'TomcatMinSpareThreads'
         TomcatProtocol: !Ref 'TomcatProtocol'
         TomcatRedirectPort: !Ref 'TomcatRedirectPort'
+        BastionHostRequired: !Ref 'BastionHostRequired'
 
 Outputs:
   ServiceURL:
@@ -634,6 +654,7 @@ Outputs:
     Description: The Load Balancer URL
     Value: !GetAtt 'CrowdDCStack.Outputs.LoadBalancerURL'
   BastionIP:
+    Condition: ProvisionBastion
     Description: Bastion node IP (use as a jumpbox to connect to the nodes)
     Value: !GetAtt 'VPCStack.Outputs.BastionPubIp'
   SGname:

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -33,11 +33,15 @@ Metadata:
           - DBStorageEncrypted
           - DBStorageType
       - Label:
+          default: Bastion host utilization
+        Parameters:
+          - BastionHostRequired
+          - KeyPairName
+      - Label:
           default: Networking
         Parameters:
           - InternetFacingLoadBalancer
           - CidrBlock
-          - KeyPairName
           - SSLCertificateARN
       - Label:
           default: DNS (Optional)
@@ -119,6 +123,8 @@ Metadata:
         default: Version *
       JvmHeapOverride:
         default: JVM Heap Size Override
+      BastionHostRequired:
+        default: Use Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       MailEnabled:
@@ -416,9 +422,16 @@ Parameters:
     Default: ''
     Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to grant access to Crowd's EC2 instances through the ASI's Bastion host (if it exists). If 'true', remember to provide an EC2 Key Pair. If your ASI does not have a Bastion host, set this to 'false'.
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
     Type: String
     Default: ''
   MailEnabled:
@@ -520,6 +533,10 @@ Conditions:
     !Equals [!Ref InternetFacingLoadBalancer, 'true']
   GovCloudCondition:
     !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+  UseBastionHost: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
+
 Mappings:
   AWSInstanceType2Arch:
     c4.large:
@@ -1042,7 +1059,7 @@ Resources:
       KeyName: !If
         - KeyProvided
         - !Ref KeyPairName
-        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
+        - Ref: AWS::NoValue
       IamInstanceProfile: !Ref ClusterNodeInstanceProfile
       ImageId:
         !FindInMap
@@ -1252,14 +1269,17 @@ Resources:
           FromPort: 22
           ToPort: 22
           CidrIp: !Ref CidrBlock
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp:
-            !Sub
-              - "${BastionIp}/32"
-              - BastionIp:
-                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+        - !If
+          - UseBastionHost
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp:
+              !Sub
+                - "${BastionIp}/32"
+                - BastionIp:
+                    Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+          - Ref: AWS::NoValue
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80


### PR DESCRIPTION
[Documentation ticket](https://bulldog.internal.atlassian.com/browse/DCD-1008)


Proposed changes for making Bastion host provisioning/usage optional. See associated PR for ASI changes:

https://github.com/atlassian/quickstart-atlassian-services/pull/34

What changes look and read like when rendered:

**templates/quickstart-crowd-dc-with-vpc.template.yaml**
![image](https://user-images.githubusercontent.com/409063/81266202-b7642600-9087-11ea-8a1c-62b4cf9e7a51.png)

 **templates/quickstart-crowd-dc.template.yaml**
![image](https://user-images.githubusercontent.com/409063/81266308-e4b0d400-9087-11ea-90be-d61a2aa940f6.png)

**Passing CI on branch CI**
https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSCROWD1-2

Additional details on how existing clusters will now work with this optional behavior going forward here:
https://hello.atlassian.net/wiki/spaces/~560412609/pages/719468588/DC+AWS+QuickStart+-+Making+Bastions+optional