### PR TITLE
Updated ssh key description & fixed SSL policy

### DIFF
--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -464,8 +464,8 @@ Parameters:
     Description: Whether to provision a bastion host instance. If 'true', provide an Amazon EC2 key pair (otherwise, you won't be able to use the bastion host to access Crowd instances).
     Type: String
   KeyPairName:
-    ConstraintDescription: Must be the name of an existing Amazon EC2 key pair.
-    Description: Public/private EC2 key pairs to securely access the bastion host.
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair. Note the supplied value must not include the file extension.
+    Description: Public/private EC2 Key Pairs (without file extension) to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   MailEnabled:

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -447,8 +447,8 @@ Parameters:
     Description: Whether to grant access to Crowd's Amazon EC2 instances through the ASI's bastion host (if it exists). If 'true', remember to provide an EC2 key pair. If your ASI does not have a bastion host, set the value to 'false'.
     Type: String
   KeyPairName:
-    ConstraintDescription: Must be the name of an existing Amazon EC2 key pair.
-    Description: Public/private EC2 key pairs for securely accessing the bastion host.
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair. Note the supplied value must not include the file extension.
+    Description: Public/private EC2 Key Pairs (without file extension) to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   MailEnabled:

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -969,10 +969,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1141,9 +1141,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1231,9 +1231,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
 
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -1266,7 +1266,7 @@ Resources:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
       Protocol: HTTPS
-      SslPolicy: "TLSv1.2"
+      SslPolicy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   MainTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -1296,9 +1296,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1377,9 +1377,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1411,9 +1411,9 @@ Resources:
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: d0035bd4453dffaf3a28a1bfda1c6057cc27614d"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2021-08-06T00:53:03Z"
       EnableKeyRotation: true
   EncryptionKeyAlias:
     Condition: UseDatabaseEncryption


### PR DESCRIPTION
Description of the 'key Pairs Name SSH' field modified to reduce the confusion during Quickstart set up.

SSL policy updated to fix the break in internal CI when sync with upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
