### PR TITLE
DCD-1333 Disable keypairs for Taskcat CI builds

### DIFF
--- a/ci/params/default/quickstart-crowd-default-params.json
+++ b/ci/params/default/quickstart-crowd-default-params.json
@@ -24,10 +24,6 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    },
-    {
         "ParameterKey": "CidrBlock",
         "ParameterValue": "0.0.0.0/0"
     },

--- a/ci/params/ssl-and-dns/quickstart-crowd-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-crowd-ci-params.json
@@ -24,10 +24,6 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    },
-    {
         "ParameterKey": "CidrBlock",
         "ParameterValue": "0.0.0.0/0"
     },

--- a/ci/quickstart-crowd-dc-params.json
+++ b/ci/quickstart-crowd-dc-params.json
@@ -44,10 +44,6 @@
         "ParameterValue": "10.0.0.0/16"
     },
     {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    },
-    {
         "ParameterKey": "BastionHostRequired",
         "ParameterValue": "false"
   }


### PR DESCRIPTION
*DCD-1333*

*Disable keypairs for Taskcat CI builds.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.