### PR TITLE
DCD-956 Fix cfn-signal in AutoScaling LaunchConfiguration

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -951,6 +951,10 @@ Resources:
   # Crowd node config
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref ClusterNodeMin
+        Timeout: PT15M
     Properties:
       DesiredCapacity: !Ref ClusterNodeMin
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig
@@ -1129,7 +1133,7 @@ Resources:
             - !Sub ["/opt/aws/bin/cfn-init -v --stack ${StackName}", {StackName: !Ref "AWS::StackName"}]
             - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}\n", {Region: !Ref "AWS::Region"}]
             - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", {StackName: !Ref "AWS::StackName"}]
-            - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}", {Region: !Ref "AWS::Region"}]
+            - !Sub [" --resource ClusterNodeGroup --region ${Region}", {Region: !Ref "AWS::Region"}]
   # Elastic file system
   ElasticFileSystem:
     Type: AWS::EFS::FileSystem


### PR DESCRIPTION
*DCD-956*

*Creation policy to wait until all the instances are up and running.*
*Fix cfn-init.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.