### PR TITLE
CLIP-1562 EFS Backup automatically enabled

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -18,3 +18,5 @@ ignore_checks:
   - W9003
   # EIAMPolicyWildcardResource: IAM policy should not allow * resource; This method in this in this policy support granular permissions
   - EIAMPolicyWildcardResource
+  # EFSFilesystemEncryptionEnabled: EFS Encryption is disabled by default
+  - EFSFilesystemEncryptionEnabled

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -1138,6 +1138,8 @@ Resources:
   ElasticFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:
+      BackupPolicy:
+        Status: ENABLED
       FileSystemTags:
         - Key: Name
           Value: !Join [' ', [!Ref 'AWS::StackName', 'cluster shared-files']]


### PR DESCRIPTION
*CLIP-1562, CLIP-1593*

- EFS Backup automatically enabled
- Ignore EFS encryption lint warning in AWS QS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.